### PR TITLE
Improve documentation around configuring Ecto repos

### DIFF
--- a/lib/prometheus_telemetry/metrics/ecto.ex
+++ b/lib/prometheus_telemetry/metrics/ecto.ex
@@ -35,6 +35,14 @@ if PrometheusTelemetry.Utils.app_loaded?(:ecto) do
     end
 
     def metrics(prefix) do
+      if is_atom(prefix) and Code.ensure_loaded?(prefix) do
+        raise ArgumentError, """
+        expects an atom or a string prefix. To configure Ecto metrics using \
+        a module, use PrometheusTelemetry.Metrics.Ecto.metrics_for_repo/1 or \
+        PrometheusTelemetry.Metrics.Ecto.metrics_for_repos/1.
+        """
+      end
+
       event_name = create_event_name(prefix)
 
       [

--- a/test/prometheus_telemetry/metrics/ecto_test.exs
+++ b/test/prometheus_telemetry/metrics/ecto_test.exs
@@ -2,6 +2,24 @@ defmodule PrometheusTelemetry.Metrics.EctoTest do
   use ExUnit.Case, async: true
   alias PrometheusTelemetry.Metrics.Ecto
 
+  describe "metrics/1" do
+    setup _ do
+      Module.create(MyEctoApp.Repo, nil, Macro.Env.location(__ENV__))
+
+      :ok
+    end
+
+    test "rejects module as prefix" do
+      assert_raise ArgumentError, ~r/^expects an atom or a string prefix/, fn ->
+        Ecto.metrics(MyEctoApp.Repo)
+      end
+
+      assert_raise ArgumentError, ~r/^expects an atom or a string prefix/, fn ->
+        Ecto.metrics([MyEctoApp.Repo, MyEctoApp.Repo.Replica1])
+      end
+    end
+  end
+
   describe "metrics_for_repos/1" do
     test "able to create a list of metrics" do
       metrics_length = length(Ecto.metrics(:asdf))


### PR DESCRIPTION
- Took a stab at adding some detail into the readme regarding Ecto metrics
- Added an exception if a module is passed to `PrometheusTelemetry.Metrics.Ecto.metrics/1`, redirecting the caller to `metrics_for_repo/1` or `metrics_for_repos/1'
- Added a test for the exception