### PR TITLE
Merge duplicated tags

### DIFF
--- a/lib/prometheus_telemetry/metrics/finch.ex
+++ b/lib/prometheus_telemetry/metrics/finch.ex
@@ -43,10 +43,9 @@ if PrometheusTelemetry.Utils.app_loaded?(:finch) do
 
         counter("finch.request_error.count",
           event_name: [:finch, :request, :exception],
-          tags: [:host, :port, :method],
+          tags: [:name, :host, :port, :method, :reason, :kind],
           tag_values: &add_extra_metadata/1,
           measurement: :count,
-          tags: [:reason, :kind, :name, :method],
           description: "Finch request error count"
         ),
 


### PR DESCRIPTION
For the `finch.request_error.count` metric, two `tags` keys are given:

https://github.com/theblitzapp/prometheus_telemetry_elixir/blob/5b7780a381dac5d2a5fae31dcb430f77c2e4ea2c/lib/prometheus_telemetry/metrics/finch.ex#L44-L51

This PR merges these two lists, to only have one with all tags.