### PR TITLE
Missing first char in shortened SQL-query

### DIFF
--- a/lib/prometheus_telemetry/metrics/ecto.ex
+++ b/lib/prometheus_telemetry/metrics/ecto.ex
@@ -167,7 +167,7 @@ if PrometheusTelemetry.Utils.app_loaded?(:ecto) do
 
     defp clamp_query_size(query) do
       if String.length(query) > @max_query_length do
-        "#{String.slice(query, 1..@max_query_length)}..."
+        "#{String.slice(query, 0, @max_query_length)}..."
       else
         query
       end


### PR DESCRIPTION
When the SQL query is longer than the configured `@max_query_length`, the query gets shortened, but the first character gets lost:

**Query:** `SELECT very_long_column_name FROM very_long_table_name`

| | Shortened (@max_query_length=50) |
| --: | --- |
| **Expeced** | `SELECT very_long_column_name FROM very_long_table_...` |
| **Actual** | `ELECT very_long_column_name FROM very_long_table_n...` |

That's because the shortening implementation does the slicing wrong:

https://github.com/theblitzapp/prometheus_telemetry_elixir/blob/5b7780a381dac5d2a5fae31dcb430f77c2e4ea2c/lib/prometheus_telemetry/metrics/ecto.ex#L169-L170

Using `1..@max_query_length` causes losing the first character. Instead of using `String.slice/2` with a range as second parameter, we should use `String.slice/3` with `0` and `@max_query_length` as second and third parameters.