### PR TITLE
Allow passing `ip` option to Cowboy

### DIFF
--- a/lib/prometheus_telemetry.ex
+++ b/lib/prometheus_telemetry.ex
@@ -21,6 +21,12 @@ defmodule PrometheusTelemetry do
           default: [],
           doc: "Exporter options",
           keys: [
+            ip: [
+              type: {:tuple, [:non_neg_integer, :non_neg_integer, :non_neg_integer, :non_neg_integer]},
+              default: {0, 0, 0, 0},
+              doc: "IP address to bind the exporter on",
+            ],
+
             port: [
               type: :integer,
               default: 4050,

--- a/lib/prometheus_telemetry/metrics_exporter_plug.ex
+++ b/lib/prometheus_telemetry/metrics_exporter_plug.ex
@@ -9,7 +9,7 @@ defmodule PrometheusTelemetry.MetricsExporterPlug do
     Plug.Cowboy.child_spec(
       scheme: opts[:protocol],
       plug: PrometheusTelemetry.Router,
-      options: [port: opts[:port]]
+      options: [ip: opts[:ip], port: opts[:port]]
     )
   end
 end


### PR DESCRIPTION
I tried to change the IP binding from `{0, 0, 0, 0}` to `{127, 0, 0, 1}` but there is currently no way to pass the `ip`-option to `Plug.Cowboy`, so I added it :wink: 